### PR TITLE
NacosDriver::isRegistered server response errCode: 400 not found

### DIFF
--- a/src/NacosDriver.php
+++ b/src/NacosDriver.php
@@ -151,6 +151,10 @@ class NacosDriver implements DriverInterface
             return false;
         }
 
+        if ($response->getStatusCode() === 400 && strpos((string) $response->getBody(), 'not found') > 0) {
+            return false;
+        }
+
         if ($response->getStatusCode() !== 200) {
             throw new RequestException(sprintf('Failed to get nacos service %s!', $name), $response->getStatusCode());
         }


### PR DESCRIPTION
兼容同时使用nacos 1.x、2.x ，判断服务是否已注册返回false，再重新注册服务。